### PR TITLE
Add install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Source plugin for pulling data into [Gatsby](https://www.gatsbyjs.org/) from a [Trello](https://trello.com) board.
 
 ## Install
+```
+ npm install --save gatsby-source-trello-board
+```
 
 ## How to use
 


### PR DESCRIPTION
I noticed the install instructions were missing on the Gatsby site here:
https://www.gatsbyjs.org/packages/gatsby-source-trello-board/
and wanted to contribute a fix.